### PR TITLE
hotfix: random messages are being recognized as commands 

### DIFF
--- a/src/main/kotlin/com/github/seliba/devcordbot/constants/Constants.kt
+++ b/src/main/kotlin/com/github/seliba/devcordbot/constants/Constants.kt
@@ -27,7 +27,7 @@ object Constants {
     /**
      * The prefix used for commands.
      */
-    val prefix: Regex = "((?i)s(u(do)?)?(?-i)|!)".toRegex()
+    val prefix: Regex = "^((?i)s(u(do)?)?(?-i)|!)".toRegex()
 
     /**
      * Prefix used for help messages.


### PR DESCRIPTION
e.g. `ism` is mock