### PR TITLE
AutoHelp Improvements

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -15,6 +15,6 @@
 #
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.2.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.4-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
- Fix bug in regex that detected spigot error log messages as an exception preventing auto help from parsing actual exception
- Scrub tru message to find any possible source for src code and only stop if you found one or don't have any more possibilities
- Add support for invalid plugin.yml tag