### PR TITLE
feature/autohelp overhaul

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,3 +25,5 @@ CSE_ID="21j34jk5213j12"
 REDEPLOY_HOST="http://localhost:3333/hooks/redeploy-bot"
 REDEPLOY_TOKEN="abc123"
 HASTE_HOST="https://hasteb.in"
+
+GOOGLE_APPLICATION_CREDENTIALS="ServiceAccountKey.json"

--- a/.gitignore
+++ b/.gitignore
@@ -126,3 +126,6 @@ gradle-app.setting
 *.toml
 
 # End of https://www.gitignore.io/api/gradle,kotlin,intellij+iml
+
+# GCP Vision
+ServiceAccountKey.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,11 @@
-FROM adoptopenjdk/openjdk13-openj9
+FROM adoptopenjdk/openjdk14-openj9 as builder
+WORKDIR /usr/app
+COPY . .
+RUN ./gradlew installDist -Dorg.gradle.daemon=false
+
+FROM adoptopenjdk/openjdk14-openj9
 
 WORKDIR /usr/app
-COPY build/libs/*-all.jar ./bot.jar
+COPY build/install/devcordbot/ .
 
-ENTRYPOINT ["java","-jar","./bot.jar"]
+ENTRYPOINT ["/usr/app/bin/devcordbot"]

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -66,9 +66,11 @@ dependencies {
     implementation("com.squareup.okhttp3", "okhttp", "4.4.0")
     implementation("org.jetbrains.kotlinx", "kotlinx-cli", "0.2.1")
     implementation("com.codewaves.codehighlight", "codehighlight", "1.0.2")
-    implementation("com.github.JohnnyJayJay", "javadox", "adb3613484")
+    implementation("com.github.DRSchlaubi", "javadox", "bd741be")
     implementation("com.vladsch.flexmark", "flexmark-html2md-converter", "0.60.2")
     implementation("com.google.apis", "google-api-services-customsearch", "v1-rev20200408-1.30.9")
+    implementation("com.google.cloud", "google-cloud-vision", "1.99.3")
+
 
     // Testing
     testImplementation("org.mockito", "mockito-core", "3.3.3")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,3 +14,5 @@ services:
       - "/etc/localtime:/etc/localtime:ro"
     depends_on:
       - database
+    env_file:
+      - .env

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -15,6 +15,6 @@
 #
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/kotlin/com/github/devcordde/devcordbot/Launcher.kt
+++ b/src/main/kotlin/com/github/devcordde/devcordbot/Launcher.kt
@@ -28,6 +28,8 @@ import org.slf4j.event.Level as SLF4JLevel
 import ch.qos.logback.classic.Level
 import ch.qos.logback.classic.Logger
 import com.github.devcordde.devcordbot.constants.Constants
+import com.github.devcordde.devcordbot.core.JavaDocManager
+import com.github.devcordde.devcordbot.core.autohelp.ImageReader
 import net.dv8tion.jda.api.entities.Activity
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import org.slf4j.LoggerFactory
@@ -88,5 +90,7 @@ fun main(args: Array<String>) {
     Constants.hastebinUrl = env["HASTE_HOST"]?.toHttpUrl() ?: "https://hasteb.in".toHttpUrl()
 
     logger.info { "Launching DevCordBot..." }
+    logger.info { "OCR Available: ${ImageReader.available}" }
+    JavaDocManager.javadocPool // for some reason the object instance is made lazly which is to late here
     DevCordBot(token, games, env, debugMode)
 }

--- a/src/main/kotlin/com/github/devcordde/devcordbot/command/CommandPlace.kt
+++ b/src/main/kotlin/com/github/devcordde/devcordbot/command/CommandPlace.kt
@@ -26,12 +26,12 @@ enum class CommandPlace {
     /**
      * Private Messages
      */
-    PM,
+    PRIVATE_MESSAGE,
 
     /**
      * Guild Messages
      */
-    GM,
+    GUILD_MESSAGE,
 
     /**
      * Guild and Private Messages
@@ -45,8 +45,8 @@ enum class CommandPlace {
     fun matches(message: Message): Boolean {
         return when (this) {
             ALL -> true
-            PM -> message.channelType == ChannelType.PRIVATE
-            GM -> message.channelType == ChannelType.TEXT
+            PRIVATE_MESSAGE -> message.channelType == ChannelType.PRIVATE
+            GUILD_MESSAGE -> message.channelType == ChannelType.TEXT
         }
     }
 }

--- a/src/main/kotlin/com/github/devcordde/devcordbot/commands/general/AbstractJavadocCommand.kt
+++ b/src/main/kotlin/com/github/devcordde/devcordbot/commands/general/AbstractJavadocCommand.kt
@@ -36,7 +36,7 @@ import net.dv8tion.jda.api.entities.MessageEmbed
 /**
  * Abstract implementation for javadoc search command.
  */
-abstract class AbstractJavadocCommand() : AbstractCommand() {
+abstract class AbstractJavadocCommand : AbstractCommand() {
     override val usage: String
         get() = "[reference]"
     override val permission: Permission = Permission.ANY

--- a/src/main/kotlin/com/github/devcordde/devcordbot/commands/general/AbstractJavadocCommand.kt
+++ b/src/main/kotlin/com/github/devcordde/devcordbot/commands/general/AbstractJavadocCommand.kt
@@ -41,7 +41,7 @@ abstract class AbstractJavadocCommand : AbstractCommand() {
         get() = "[reference]"
     override val permission: Permission = Permission.ANY
     override val category: CommandCategory = CommandCategory.GENERAL
-    override val commandPlace: CommandPlace = CommandPlace.GM
+    override val commandPlace: CommandPlace = CommandPlace.GUILD_MESSAGE
 
     /**
      * Parses the command in [context].

--- a/src/main/kotlin/com/github/devcordde/devcordbot/commands/general/DocumentedVersion.kt
+++ b/src/main/kotlin/com/github/devcordde/devcordbot/commands/general/DocumentedVersion.kt
@@ -27,12 +27,12 @@ enum class DocumentedVersion(
     V_6("JAVA", "https://docs.oracle.com/javase/6/docs/api/overview-tree.html", "6"),
     V_7("JAVA", "https://docs.oracle.com/javase/7/docs/api/overview-tree.html", "7"),
     V_8("JAVA", "https://docs.oracle.com/javase/8/docs/api/overview-tree.html", "8"),
-    V_9("JAVA", "https://docs.oracle.com/javase/9/docs/api/overview-tree.html", "9"),
-    V_10("JAVA", "https://docs.oracle.com/javase/10/docs/api/overview-tree.html", "10"),
-    V_11("JAVA", "https://docs.oracle.com/en/java/javase/11/docs/api/overview-tree.html", "11"),
-    V_12("JAVA", "https://docs.oracle.com/en/java/javase/12/docs/api/overview-tree.html", "12"),
-    V_13("JAVA", "https://docs.oracle.com/en/java/javase/13/docs/api/overview-tree.html", "13"),
-    V_14("JAVA", "https://download.java.net/java/GA/jdk14/docs/api/overview-tree.html", "14"),
+    V_9("JAVA", "https://cr.openjdk.java.net/~iris/se/9/latestSpec/api/overview-tree.html", "9"),
+    V_10("JAVA", "https://cr.openjdk.java.net/~iris/se/10/latestSpec/api/overview-tree.html", "10"),
+    V_11("JAVA", "https://cr.openjdk.java.net/~iris/se/11/latestSpec/api/overview-tree.html", "11"),
+    V_12("JAVA", "https://cr.openjdk.java.net/~iris/se/12/latestSpec/api/overview-tree.html", "12"),
+    V_13("JAVA", "https://cr.openjdk.java.net/~iris/se/13/latestSpec/api/overview-tree.html", "13"),
+    V_14("JAVA", "https://cr.openjdk.java.net/~iris/se/14/latestSpec/api/overview-tree.html", "14"),
 
     // Spigot
     V_1_7_10("SPIGOT", "https://helpch.at/docs/1.7.10/overview-tree.html", "1.7.10"),

--- a/src/main/kotlin/com/github/devcordde/devcordbot/commands/general/GoogleCommand.kt
+++ b/src/main/kotlin/com/github/devcordde/devcordbot/commands/general/GoogleCommand.kt
@@ -30,7 +30,7 @@ import com.google.api.services.customsearch.Customsearch
 /**
  * Google command.
  */
-class GoogleCommand() : AbstractCommand() {
+class GoogleCommand : AbstractCommand() {
 
     private val search =
         Customsearch.Builder(GoogleNetHttpTransport.newTrustedTransport(), JacksonFactory(), null)

--- a/src/main/kotlin/com/github/devcordde/devcordbot/commands/general/GoogleCommand.kt
+++ b/src/main/kotlin/com/github/devcordde/devcordbot/commands/general/GoogleCommand.kt
@@ -44,7 +44,7 @@ class GoogleCommand : AbstractCommand() {
     override val usage: String = "<query>"
     override val permission: Permission = Permission.ANY
     override val category: CommandCategory = CommandCategory.GENERAL
-    override val commandPlace: CommandPlace = CommandPlace.GM
+    override val commandPlace: CommandPlace = CommandPlace.GUILD_MESSAGE
 
     override suspend fun execute(context: Context) {
         val query = context.args.join()

--- a/src/main/kotlin/com/github/devcordde/devcordbot/commands/general/GoogleCommand.kt
+++ b/src/main/kotlin/com/github/devcordde/devcordbot/commands/general/GoogleCommand.kt
@@ -23,19 +23,11 @@ import com.github.devcordde.devcordbot.command.context.Context
 import com.github.devcordde.devcordbot.command.permission.Permission
 import com.github.devcordde.devcordbot.constants.Embeds
 import com.github.devcordde.devcordbot.menu.Paginator
-import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport
-import com.google.api.client.json.jackson2.JacksonFactory
-import com.google.api.services.customsearch.Customsearch
 
 /**
  * Google command.
  */
 class GoogleCommand : AbstractCommand() {
-
-    private val search =
-        Customsearch.Builder(GoogleNetHttpTransport.newTrustedTransport(), JacksonFactory(), null)
-            .setApplicationName("DevcordBot")
-            .build()
 
     override val aliases: List<String> = listOf("google", "search", "g")
     override val displayName: String = "google"

--- a/src/main/kotlin/com/github/devcordde/devcordbot/commands/general/GoogleCommand.kt
+++ b/src/main/kotlin/com/github/devcordde/devcordbot/commands/general/GoogleCommand.kt
@@ -30,7 +30,7 @@ import com.google.api.services.customsearch.Customsearch
 /**
  * Google command.
  */
-class GoogleCommand(private val apiKey: String, private val engineId: String) : AbstractCommand() {
+class GoogleCommand() : AbstractCommand() {
 
     private val search =
         Customsearch.Builder(GoogleNetHttpTransport.newTrustedTransport(), JacksonFactory(), null)
@@ -51,13 +51,9 @@ class GoogleCommand(private val apiKey: String, private val engineId: String) : 
 
         if (query.isBlank()) return context.sendHelp().queue()
 
-        val results = with(search.cse().list(query)) {
-            key = apiKey
-            cx = engineId
-            execute()
-        }.items
+        val results = context.bot.googler.google(query)
 
-        if (results == null || results.isEmpty()) {
+        if (results.isEmpty()) {
             return context.respond(
                 Embeds.error(
                     title = "Keine Suchergebnisse gefunden",

--- a/src/main/kotlin/com/github/devcordde/devcordbot/commands/general/JavadocCommand.kt
+++ b/src/main/kotlin/com/github/devcordde/devcordbot/commands/general/JavadocCommand.kt
@@ -16,10 +16,10 @@
 
 package com.github.devcordde.devcordbot.commands.general
 
-import com.github.johnnyjayjay.javadox.JavadocParser
-import com.github.johnnyjayjay.javadox.Javadocs
 import com.github.devcordde.devcordbot.command.context.Context
 import com.github.devcordde.devcordbot.constants.Embeds
+import com.github.johnnyjayjay.javadox.JavadocParser
+import com.github.johnnyjayjay.javadox.Javadocs
 import org.jsoup.Jsoup
 
 /**

--- a/src/main/kotlin/com/github/devcordde/devcordbot/commands/general/TagCommand.kt
+++ b/src/main/kotlin/com/github/devcordde/devcordbot/commands/general/TagCommand.kt
@@ -239,7 +239,7 @@ class TagCommand : AbstractCommand() {
         override val displayName: String = "List"
         override val description: String = "Gibt eine Liste aller Tags aus"
         override val usage: String = ""
-        override val commandPlace: CommandPlace = CommandPlace.GM
+        override val commandPlace: CommandPlace = CommandPlace.GUILD_MESSAGE
 
         override suspend fun execute(context: Context) {
             val tags = transaction { Tag.all().orderBy(Tags.usages to SortOrder.DESC).map(Tag::name) }
@@ -255,7 +255,7 @@ class TagCommand : AbstractCommand() {
         override val displayName: String = "from"
         override val description: String = "Gibt eine Liste aller Tags eines bestimmten Benutzers aus"
         override val usage: String = "<@user>"
-        override val commandPlace: CommandPlace = CommandPlace.GM
+        override val commandPlace: CommandPlace = CommandPlace.GUILD_MESSAGE
 
         override suspend fun execute(context: Context) {
             val user = context.args.optionalUser(0, jda = context.jda) ?: context.author
@@ -273,7 +273,7 @@ class TagCommand : AbstractCommand() {
         override val displayName: String = "search"
         override val description: String = "Gibt die ersten 25 Tags mit dem angegebenen Namen"
         override val usage: String = "<query>"
-        override val commandPlace: CommandPlace = CommandPlace.GM
+        override val commandPlace: CommandPlace = CommandPlace.GUILD_MESSAGE
 
         override suspend fun execute(context: Context) {
             if (context.args.isEmpty()) {

--- a/src/main/kotlin/com/github/devcordde/devcordbot/commands/general/_JavadocCommands.kt
+++ b/src/main/kotlin/com/github/devcordde/devcordbot/commands/general/_JavadocCommands.kt
@@ -54,7 +54,7 @@ fun OracleJavaDocCommand(): AbstractCommand = URLJavaDocCommand(
     "java",
     DocumentedVersion.V_10.url,
     listOf("doc", "docs"),
-    "javaodc",
+    "javadoc",
     "Lässt dich javadoc benutzen"
 )
 

--- a/src/main/kotlin/com/github/devcordde/devcordbot/commands/general/_JavadocCommands.kt
+++ b/src/main/kotlin/com/github/devcordde/devcordbot/commands/general/_JavadocCommands.kt
@@ -18,31 +18,40 @@
 
 package com.github.devcordde.devcordbot.commands.general
 
-import com.github.johnnyjayjay.javadox.JavadocParser
-import com.github.johnnyjayjay.javadox.Javadocs
 import com.github.devcordde.devcordbot.command.AbstractCommand
 import com.github.devcordde.devcordbot.command.context.Context
-import org.jsoup.Jsoup
+import com.github.devcordde.devcordbot.constants.Embeds
+import com.github.devcordde.devcordbot.core.JavaDocManager
 
-private fun URLJavaDocCommand(url: String, aliases: List<String>, displayName: String, description: String) =
+private fun URLJavaDocCommand(
+    key: String,
+    url: String,
+    aliases: List<String>,
+    displayName: String,
+    description: String
+) =
     object : AbstractJavadocCommand() {
         override val aliases: List<String> = aliases
         override val displayName: String = displayName
         override val description: String = description
 
-        private val parser: JavadocParser = JavadocParser(htmlRenderer::convert)
-
-        private val docs: Javadocs = Javadocs(tree = url, parser = parser) {
-            Jsoup.connect(it).userAgent("Mozilla").get()
+        override suspend fun execute(context: Context) {
+            val docs = JavaDocManager.javadocPool[key]
+                ?: return context.respond(
+                    Embeds.error(
+                        "Dieser Befehl ist leider derzeit nicht verfügbar!",
+                        "Leider gab es ein Problem während die Dokumentation geladen wurde."
+                    )
+                ).queue()
+            execute(context, url, docs)
         }
-
-        override suspend fun execute(context: Context) = execute(context, url, docs)
     }
 
 /**
  * Command for oracle (java 10) doc.
  */
 fun OracleJavaDocCommand(): AbstractCommand = URLJavaDocCommand(
+    "java",
     DocumentedVersion.V_10.url,
     listOf("doc", "docs"),
     "javaodc",
@@ -53,6 +62,7 @@ fun OracleJavaDocCommand(): AbstractCommand = URLJavaDocCommand(
  * Command for spigot (1.15.2) doc.
  */
 fun SpigotJavaDocCommand(): AbstractCommand = URLJavaDocCommand(
+    "org.bukkit",
     DocumentedVersion.V_1_16.url,
     listOf("spigot", "1.16", "116", "sdoc"),
     "javaodc",
@@ -64,6 +74,7 @@ fun SpigotJavaDocCommand(): AbstractCommand = URLJavaDocCommand(
  * Because some YT tutorial guy had to make videos for an 5 year old version
  */
 fun SpigotLegacyJavaDocCommand(): AbstractCommand = URLJavaDocCommand(
+    "spigot-legacy",
     DocumentedVersion.V_1_8_8.url,
     listOf("spigotlegacy", "1.8", "118", "sldoc"),
     "javaodc",

--- a/src/main/kotlin/com/github/devcordde/devcordbot/commands/general/jdoodle/EvalCommand.kt
+++ b/src/main/kotlin/com/github/devcordde/devcordbot/commands/general/jdoodle/EvalCommand.kt
@@ -43,7 +43,7 @@ class EvalCommand : AbstractCommand() {
     override val usage: String = MarkdownSanitizer.escape("\n```<language>\n<code>\n```")
     override val permission: Permission = Permission.ANY
     override val category: CommandCategory = CommandCategory.GENERAL
-    override val commandPlace: CommandPlace = CommandPlace.GM
+    override val commandPlace: CommandPlace = CommandPlace.GUILD_MESSAGE
 
     init {
         registerCommands(ListCommand())

--- a/src/main/kotlin/com/github/devcordde/devcordbot/commands/moderation/StarboardCommand.kt
+++ b/src/main/kotlin/com/github/devcordde/devcordbot/commands/moderation/StarboardCommand.kt
@@ -42,7 +42,7 @@ class StarboardCommand : AbstractCommand() {
     override val usage: String = ""
     override val permission: Permission = Permission.MODERATOR
     override val category: CommandCategory = CommandCategory.MODERATION
-    override val commandPlace: CommandPlace = CommandPlace.GM
+    override val commandPlace: CommandPlace = CommandPlace.GUILD_MESSAGE
 
     init {
         registerCommands(

--- a/src/main/kotlin/com/github/devcordde/devcordbot/constants/Constants.kt
+++ b/src/main/kotlin/com/github/devcordde/devcordbot/constants/Constants.kt
@@ -52,7 +52,23 @@ object Constants {
 
     /**
      * Regex that matches discord code blocks.
+     * https://regex101.com/r/SBv5RG/3
      */
-    val CODE_BLOCK_REGEX: Regex = "```(.*)?(?s)(.*)```".toRegex()
+    val CODE_BLOCK_REGEX: Regex =
+        "```(actionscript3|apache|applescript|asp|brainfuck|c|cfm|clojure|cmake|coffee-script|coffeescript|coffee|cpp|cs|csharp|css|csv|bash|diff|elixir|erb|go|haml|http|java|javascript|json|jsx|less|lolcode|make|markdown|matlab|nginx|objectivec|pascal|PHP|Perl|python|profile|rust|salt|saltstate|shell|sh|zsh|bash|sql|scss|sql|svg|swift|rb|jruby|ruby|smalltalk|vim|viml|volt|vhdl|vue|xml|yaml)?([^`]*)```".toRegex(
+            RegexOption.MULTILINE
+        )
+
+    /**
+     * A regex matching a lot of common (non-user) packages.
+     *
+     * Results in (?:<packages>).*
+     */
+    val KNOWN_PACKAGES: Regex = listOf(
+        "java", "javax", "javafx", // Java
+        "com.google", "org.apache", "com.jetbrains", "org.jetbrains", "okhttp3", // publishers of big libs
+        "net.minecraft", "org.bukkit", "org.spigotmc", "net.md_5", "co.aikar", "com.destroystokyo", // mc servers
+        "net.milkbowl", "me.clip", "org.sk89q", "com.onarandombox" // known libraries
+    ).joinToString(prefix = "(?:", separator = "|", postfix = ").*").toRegex()
 
 }

--- a/src/main/kotlin/com/github/devcordde/devcordbot/core/DevCordBot.kt
+++ b/src/main/kotlin/com/github/devcordde/devcordbot/core/DevCordBot.kt
@@ -18,6 +18,7 @@ package com.github.devcordde.devcordbot.core
 
 import com.github.devcordde.devcordbot.command.CommandClient
 import com.github.devcordde.devcordbot.util.GithubUtil
+import com.github.devcordde.devcordbot.util.Googler
 import net.dv8tion.jda.api.JDA
 import net.dv8tion.jda.api.entities.Guild
 import okhttp3.OkHttpClient
@@ -70,4 +71,9 @@ interface DevCordBot {
      * See [GithubUtil].
      */
     val github: GithubUtil
+
+    /**
+     * See [Googler].
+     */
+    val googler: Googler
 }

--- a/src/main/kotlin/com/github/devcordde/devcordbot/core/DevCordBotImpl.kt
+++ b/src/main/kotlin/com/github/devcordde/devcordbot/core/DevCordBotImpl.kt
@@ -35,6 +35,7 @@ import com.github.devcordde.devcordbot.event.MessageListener
 import com.github.devcordde.devcordbot.listeners.DatabaseUpdater
 import com.github.devcordde.devcordbot.listeners.SelfMentionListener
 import com.github.devcordde.devcordbot.util.GithubUtil
+import com.github.devcordde.devcordbot.util.Googler
 import com.zaxxer.hikari.HikariDataSource
 import io.github.cdimascio.dotenv.Dotenv
 import mu.KotlinLogging
@@ -78,6 +79,8 @@ internal class DevCordBotImpl(
     override val github: GithubUtil = GithubUtil(httpClient)
     override val starboard: Starboard =
         Starboard(env["STARBOARD_CHANNEL_ID"]?.toLong() ?: error("STARBOARD_CHANNEL_ID is required in .env"))
+
+    override val googler: Googler = Googler(env["CSE_KEY"]!!, env["CSE_ID"]!!)
 
     override val jda: JDA = JDABuilder.create(
         token,
@@ -212,14 +215,9 @@ internal class DevCordBotImpl(
             OracleJavaDocCommand(),
             SpigotJavaDocCommand(),
             SpigotLegacyJavaDocCommand(),
-            CleanupCommand()
+            CleanupCommand(),
+            GoogleCommand()
         )
-
-        val cseKey = env["CSE_KEY"]
-        val cseId = env["CSE_ID"]
-        if (cseKey != null && cseId != null && cseKey.isNotBlank() && cseId.isNotBlank()) {
-            commandClient.registerCommands(GoogleCommand(cseKey, cseId))
-        }
 
         val redeployHost = env["REDEPLOY_HOST"]
         val redeployToken = env["REDEPLOY_TOKEN"]

--- a/src/main/kotlin/com/github/devcordde/devcordbot/core/DevCordBotImpl.kt
+++ b/src/main/kotlin/com/github/devcordde/devcordbot/core/DevCordBotImpl.kt
@@ -222,12 +222,6 @@ internal class DevCordBotImpl(
             GoogleCommand()
         )
 
-        val cseKey = env["CSE_KEY"]
-        val cseId = env["CSE_ID"]
-        if (cseKey != null && cseId != null && cseKey.isNotBlank() && cseId.isNotBlank()) {
-            commandClient.registerCommands(GoogleCommand(cseKey, cseId))
-        }
-
         val redeployHost = env["REDEPLOY_HOST"]
         val redeployToken = env["REDEPLOY_TOKEN"]
         if (redeployHost != null && redeployToken != null && redeployHost.isNotBlank() && redeployToken.isNotBlank()) {

--- a/src/main/kotlin/com/github/devcordde/devcordbot/core/JavaDocManager.kt
+++ b/src/main/kotlin/com/github/devcordde/devcordbot/core/JavaDocManager.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2020 Daniel Scherf & Michael Rittmeister & Julian König
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package com.github.devcordde.devcordbot.core
+
+import com.github.devcordde.devcordbot.commands.general.AbstractJavadocCommand
+import com.github.devcordde.devcordbot.commands.general.DocumentedVersion
+import com.github.johnnyjayjay.javadox.JavadocParser
+import com.github.johnnyjayjay.javadox.Javadocs
+import org.jsoup.Jsoup
+
+object JavaDocManager {
+
+    private val parser: JavadocParser = JavadocParser(AbstractJavadocCommand.htmlRenderer::convert)
+
+    val javadocPool: Map<String, Javadocs> = mapOf(
+        "java" to makeJavadoc(DocumentedVersion.V_10.url),
+        "org.bukkit" to makeJavadoc(DocumentedVersion.V_1_16.url),
+        "org.spigotmc" to makeJavadoc(DocumentedVersion.V_1_16.url)
+    )
+
+    private fun makeJavadoc(url: String) = Javadocs(tree = url, parser = parser) {
+        Jsoup.connect(it).userAgent("Mozilla").get()
+    }
+}

--- a/src/main/kotlin/com/github/devcordde/devcordbot/core/JavaDocManager.kt
+++ b/src/main/kotlin/com/github/devcordde/devcordbot/core/JavaDocManager.kt
@@ -39,9 +39,9 @@ object JavaDocManager {
     val javadocPool: Map<String, Javadocs> = mutableMapOf()
 
     init {
-        makeJavadoc("java", DocumentedVersion.V_10.url, false)
-        val spigot = makeJavadoc("org.bukkit", DocumentedVersion.V_1_16.url, false)
-        makeJavadoc("spigot-legacy", DocumentedVersion.V_1_8_8.url, false)
+        makeJavadoc("java", DocumentedVersion.V_10.url)
+        val spigot = makeJavadoc("org.bukkit", DocumentedVersion.V_1_16.url)
+        makeJavadoc("spigot-legacy", DocumentedVersion.V_1_8_8.url)
         if (spigot != null) {
             (javadocPool as MutableMap<String, Javadocs>)["org.spigotmc"] = spigot
         }

--- a/src/main/kotlin/com/github/devcordde/devcordbot/core/autohelp/AutoHelp.kt
+++ b/src/main/kotlin/com/github/devcordde/devcordbot/core/autohelp/AutoHelp.kt
@@ -16,31 +16,14 @@
 
 package com.github.devcordde.devcordbot.core.autohelp
 
-import com.github.devcordde.devcordbot.constants.Constants
-import com.github.devcordde.devcordbot.constants.Embeds
-import com.github.devcordde.devcordbot.constants.Emotes
 import com.github.devcordde.devcordbot.core.DevCordBot
 import com.github.devcordde.devcordbot.database.DatabaseDevCordUser
-import com.github.devcordde.devcordbot.database.Tag
-import com.github.devcordde.devcordbot.database.Tags
-import com.github.devcordde.devcordbot.dsl.EmbedConvention
-import com.github.devcordde.devcordbot.dsl.editMessage
-import com.github.devcordde.devcordbot.dsl.sendMessage
 import com.github.devcordde.devcordbot.event.DevCordGuildMessageReceivedEvent
 import com.github.devcordde.devcordbot.event.EventSubscriber
-import com.github.devcordde.devcordbot.util.HastebinUtil
-import com.github.devcordde.devcordbot.util.await
 import io.github.cdimascio.dotenv.dotenv
-import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.future.await
-import kotlinx.coroutines.future.future
-import net.dv8tion.jda.api.entities.Message
-import net.dv8tion.jda.api.events.message.guild.GuildMessageReceivedEvent
 import org.jetbrains.exposed.sql.transactions.transaction
-import java.io.BufferedReader
-import java.io.InputStreamReader
-import java.util.concurrent.CompletableFuture
 import java.util.concurrent.Executors
 
 private val levelLimit = dotenv()["AUTO_HELP_LEVEL_LIMIT"]?.toInt() ?: 75
@@ -57,10 +40,9 @@ class AutoHelp(
     private val maxLines: Int
 ) {
 
-    private val guesser = LanguageGusser(knownLanguages)
-    private val fetcher = ContentFetcher(bot.httpClient)
-    private val beautifier = CodeBeautifier(bot.httpClient)
     private val executor = Executors.newFixedThreadPool(10).asCoroutineDispatcher()
+    private val fetcher = ContentFetcher(bot.httpClient, bot.github, executor)
+    private val brain = Brain(knownLanguages, bot.httpClient, maxLines, bot.googler)
 
     /**
      * Trigger AutoHelp on Message.
@@ -78,221 +60,49 @@ class AutoHelp(
                     || bypassWord in input)
         ) return
 
-        // Asynchronously fetch potential content
-        val attachments = fetchAttachments(event.message)
-        if (input.isNotBlank()) {
-            val hastebinMatches = findInput(HASTEBIN_PATTERN, input, ::fetchHastebin)
-            val pastebinMatches = findInput(PASTEBIN_PATTERN, input, ::fetchPastebin)
-            val ghostbinMatches = findInput(GHOSTBIN_PATTERN, input, ::fetchGhostbin)
-            val githubMatches = findInputs(GITHUB_GIST_PATTERN, input, ::fetchGithub)
+        val inputs = fetcher.fetchMessageContents(event.message)
+        val conversation by lazy { brain.findConversation(event) }
 
-            // Quit on first match
-            if (analyzeInputs(hastebinMatches, event)) {
-                pastebinMatches.cancel(true)
-                ghostbinMatches.cancel(true)
-                githubMatches.cancel(true)
-                attachments.cancel(true)
-                return
-            }
+        for (future in inputs) {
+            val userInput = future.await()
+            userInput.forEach {
+                if (it != null) {
+                    JVM_EXCEPTION_PATTERN.findAll(it).forEach { match ->
+                        val (_, name, message) = match.groupValues
+                        val elementsRaw = match.groupValues[3]
+                        val elements = STACK_TRACE_ELEMENT_PATTERN.findAll(elementsRaw).map { elementMatch ->
+                            val (_, pakage, method, className, line) = elementMatch.groupValues
+                            StackTraceElement(pakage, method, className, line.toInt())
+                        }.toList()
+                        brain.determinedException(conversation, StackTrace(name, message, elements))
+                    }
 
-            if (analyzeInputs(pastebinMatches, event)) {
-                ghostbinMatches.cancel(true)
-                githubMatches.cancel(true)
-                attachments.cancel(true)
-                return
-            }
+                    JAVA_CLASS_PATTERN.findAll(it).forEach { match ->
+                        val (_, pakage, _, name) = match.groupValues
 
-            if (analyzeInputs(githubMatches, event)) {
-                ghostbinMatches.cancel(true)
-                attachments.cancel(true)
-                return
-            }
-
-            if (analyzeInputs(ghostbinMatches, event)) {
-                attachments.cancel(true)
-                return
-            }
-
-            analyzeInput(input, false, event)
-        }
-        analyzeInputs(attachments, event, false)
-    }
-
-    private suspend fun analyzeInputs(
-        matches: CompletableFuture<List<String?>>,
-        event: GuildMessageReceivedEvent,
-        paste: Boolean = true
-    ): Boolean {
-        return matches.await().any {
-            analyzeInput(it, paste, event)
-        }
-    }
-
-    private fun findInput(
-        pattern: Regex,
-        input: String,
-        fetcher: (MatchResult) -> CompletableFuture<String?>
-    ): CompletableFuture<List<String?>> {
-        return GlobalScope.future(executor) {
-            pattern.findAll(input).toList().map {
-                fetcher(it).await()
+                        brain.determinedClass(conversation, Class(pakage, name, it))
+                    }
+                }
             }
         }
-    }
-
-    private fun findInputs(
-        pattern: Regex,
-        input: String,
-        fetcher: (MatchResult, String) -> CompletableFuture<List<String?>>
-    ): CompletableFuture<List<String?>> {
-        return GlobalScope.future(executor) {
-            pattern.findAll(input).toList().map {
-                fetcher(it, input).await()
-            }.flatten()
-        }
-    }
-
-    private suspend fun fetchAttachments(message: Message): CompletableFuture<List<String?>> {
-        return GlobalScope.future(executor) {
-            message.attachments.filter { !it.isVideo && !it.isImage }.map {
-                fetchAttachment(it)
-            }
-        }
-    }
-
-    private suspend fun fetchAttachment(attachment: Message.Attachment): String {
-        val stream = attachment.retrieveInputStream().await()
-        return BufferedReader(InputStreamReader(stream)).use { reader ->
-            reader.readText()
-        }
-    }
-
-    private fun fetchHastebin(match: MatchResult): CompletableFuture<String?> {
-        val domain = match.groupValues[1]
-        val pasteId = match.groupValues[2]
-        val rawPaste = "https://$domain/raw/$pasteId"
-        return fetcher.fetchContent(rawPaste)
-    }
-
-    private fun fetchPastebin(match: MatchResult): CompletableFuture<String?> {
-        val pasteId = match.groupValues[1]
-        val rawPaste = "https://pastebin.com/raw/$pasteId"
-        return fetcher.fetchContent(rawPaste)
-    }
-
-    private fun fetchGhostbin(match: MatchResult): CompletableFuture<String?> {
-        val pasteId = match.groupValues[1]
-        val rawPaste = "https://ghostbin.co/paste/$pasteId/raw"
-        return fetcher.fetchContent(rawPaste)
-    }
-
-    private fun fetchGithub(match: MatchResult, url: String): CompletableFuture<List<String?>> {
-        val host = match.groupValues[1]
-        val gistId = match.groupValues[3]
-        if (host == "gist.githubusercontent.com") {
-            return fetcher.fetchContent(url).thenApply { listOf(it) }
-        }
-        return bot.github.retrieveGistFiles(gistId).thenApplyAsync { fileUrls ->
-            fileUrls.map { fetcher.fetchContent(it).join() }
-        }
-    }
-
-    private suspend fun analyzeInput(
-        inputString: String?,
-        wasPaste: Boolean,
-        event: GuildMessageReceivedEvent
-    ): Boolean {
-        require(inputString != null)
-
-        // It's kind of unlikely to paste code blocks on hastebin so only check for codeblocks if it's not pasted
-        val inputBlockMatch by lazy { Constants.CODE_BLOCK_REGEX.matchEntire(inputString) }
-        val cleanInput =
-            if (!wasPaste && inputBlockMatch != null) inputBlockMatch!!.groupValues[2].trim() else inputString
-
-        val language = guesser.guessLanguage(cleanInput)
-        if (!wasPaste && language != null) {
-            val code = if (language.language.equals("java", ignoreCase = true)) {
-                beautifier.formatCode(cleanInput).await()
-            } else cleanInput
-            if (inputString.lines().size > maxLines &&
-                !Constants.prefix.containsMatchIn(inputString)
-            ) {
-                val message = event.channel.sendMessage(buildTooLongEmbed(Emotes.LOADING)).await()
-                val hastebinUrl = HastebinUtil.postErrorToHastebin(code, bot.httpClient).await()
-                message.editMessage(buildTooLongEmbed(hastebinUrl)).queue()
-            }
-        }
-
-        return JVM_EXCEPTION_PATTERN.findAll(cleanInput).any {
-            handleCommonException(it, event)
-        }
-    }
-
-    private fun buildTooLongEmbed(url: String): EmbedConvention {
-        return Embeds.warn(
-            "Huch, ist das viel?",
-            """Bitte sende lange Codeteile nicht über den Chat oder als Datei, sondern benutze stattdessen ein haste-Tool. Mehr dazu findest du bei `sudo tag haste`.
-                                        |Faustregel: Alles, was mehr als $maxLines Zeilen hat.
-                                        |Hier, ich mache das schnell für dich: $url
-                                    """.trimMargin()
-        )
-    }
-
-    private fun handleCommonException(match: MatchResult, event: GuildMessageReceivedEvent): Boolean {
-        val exceptionName = match.groupValues[1]
-        val message = match.groupValues[2]
-        if (!handleCommonException(exceptionName, message, event)) {
-            val exceptionInMessage = JVM_EXCEPTION_NAME_PATTERN.matchEntire(message) ?: return false
-            val newName = exceptionInMessage.groupValues[1]
-            val newMessage = exceptionInMessage.groupValues[2]
-            return handleCommonException(newName, newMessage, event)
-        }
-        return false
-    }
-
-    private fun handleCommonException(
-        exception: String,
-        message: String,
-        event: GuildMessageReceivedEvent
-    ): Boolean {
-        val exceptionName = exception.substring(exception.lastIndexOf('.') + 1).toLowerCase().trim()
-        val tag = when {
-            exceptionName == "nullpointerexception" -> "nullpointerexception"
-            exceptionName == "unsupportedclassversionerror" -> "class-version"
-            exceptionName == "ClassCastException" -> "casting"
-            message == "Plugin already initialized!" -> "plugin-already-initialized"
-            exceptionName == "invaliddescriptionexception" -> "plugin.yml"
-            exceptionName == "invalidpluginexception" && "cannot find main class" in message.toLowerCase() -> "main-class-not-found"
-            else -> null
-        } ?: return false
-        val tagContent = transaction { Tag.find { Tags.name eq tag }.firstOrNull() } ?: return false
-        event.channel.sendMessage(tagContent.content).queue()
-        return true
     }
 
     companion object {
-        // https://regex101.com/r/vgz86r/11
-        private val JVM_EXCEPTION_PATTERN =
-            """(?m)^(?:Exception in thread ".*")?.*?(.+?(?<=Exception|Error:))(?:\: )?(.*)(?:\R+^\s*.*)?(?:\R+^.*at .*)+""".toRegex()
+        // https://regex101.com/r/vgz86r/16
+        val JVM_EXCEPTION_PATTERN =
+            """(?m)^(?:Exception in thread ".*")?.*?(.+?(?<=Exception|Error:))(?:\: )?(.*)((?:\R+^\s*.*)?(?:\R+^.*at .*)+)""".toRegex()
 
         // https://regex101.com/r/HtaGF8/1
-        private val JVM_EXCEPTION_NAME_PATTERN =
+        val JVM_EXCEPTION_NAME_PATTERN =
             """(?m)^(?:Exception in thread ".*")?.*?(.+?(?<=Exception|Error))(?:\: )(.*)(?:\R+^\s*.*)?""".toRegex()
 
-        // https://regex101.com/r/u0QAR6/6
-        private val HASTEBIN_PATTERN =
-            "(?:https?:\\/\\/)?(?:(?:www\\.)?)?(hastebin\\.com|hasteb\\.in|paste\\.helpch\\.at)\\/(?:raw\\/)?(.+?(?=\\.|\$|\\/|#))".toRegex()
+        // https://regex101.com/r/xYGH0m/1
+        val STACK_TRACE_ELEMENT_PATTERN = "at ((?:(?:\\w)+\\.?)+)\\.(\\w+)\\((\\w+).java:([0-9]+)\\)".toRegex()
 
-        // https://regex101.com/r/N8NBDz/2
-        private val PASTEBIN_PATTERN =
-            "(?:https?:\\/\\/(?:www\\.)?)?pastebin\\.com\\/(?:raw\\/)?(.+?(?=\\.|\$|\\/|#))".toRegex()
+        // Java class pattern (should match kotlin (maybe))
+        // https://regex101.com/r/uksxY5/3
+        val JAVA_CLASS_PATTERN =
+            """(?m)package ((?:\w+\.?)+);[\s\S]*(public|private|protected) class (\w*) \{([\s\S]*)}""".toRegex()
 
-        // https://regex101.com/r/CyjiKt/2
-        private val GHOSTBIN_PATTERN =
-            "(?:https?:\\/\\/(?:www\\.)?)?(?:ghostbin\\.co)\\/(?:paste\\/)?(.+?(?=\\.|\$|\\/))(?:\\/raw)?".toRegex()
-
-        // https://regex101.com/r/AlVYjn/2
-        private val GITHUB_GIST_PATTERN =
-            "(?:https?:\\/\\/)?(gist\\.github\\.com|gist.githubusercontent.com)\\/(.+?(?=\\.|\$|\\/))\\/(.+?(?=\\.|\$|\\/|#))".toRegex()
     }
 }

--- a/src/main/kotlin/com/github/devcordde/devcordbot/core/autohelp/AutoHelp.kt
+++ b/src/main/kotlin/com/github/devcordde/devcordbot/core/autohelp/AutoHelp.kt
@@ -16,10 +16,18 @@
 
 package com.github.devcordde.devcordbot.core.autohelp
 
+import com.github.devcordde.devcordbot.constants.Constants
+import com.github.devcordde.devcordbot.constants.Embeds
+import com.github.devcordde.devcordbot.constants.Emotes
 import com.github.devcordde.devcordbot.core.DevCordBot
 import com.github.devcordde.devcordbot.database.DatabaseDevCordUser
+import com.github.devcordde.devcordbot.dsl.EmbedConvention
+import com.github.devcordde.devcordbot.dsl.editMessage
+import com.github.devcordde.devcordbot.dsl.sendMessage
 import com.github.devcordde.devcordbot.event.DevCordGuildMessageReceivedEvent
 import com.github.devcordde.devcordbot.event.EventSubscriber
+import com.github.devcordde.devcordbot.util.HastebinUtil
+import com.github.devcordde.devcordbot.util.await
 import io.github.cdimascio.dotenv.dotenv
 import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.future.await
@@ -42,7 +50,9 @@ class AutoHelp(
 
     private val executor = Executors.newFixedThreadPool(10).asCoroutineDispatcher()
     private val fetcher = ContentFetcher(bot.httpClient, bot.github, executor)
-    private val brain = Brain(knownLanguages, bot.httpClient, maxLines, bot.googler)
+    private val brain = Brain(maxLines, bot.googler)
+    private val guesser = LanguageGusser(knownLanguages)
+    private val beautifier = CodeBeautifier(bot.httpClient)
 
     /**
      * Trigger AutoHelp on Message.
@@ -56,15 +66,25 @@ class AutoHelp(
             !bot.debugMode &&
             (event.author.isBot
                     || (event.channel.parent?.id !in whitelist || event.channel.id in blacklist)
-                    || userLevel > levelLimit
                     || bypassWord in input)
         ) return
 
         val inputs = fetcher.fetchMessageContents(event.message)
+        val rawMessage = Constants.CODE_BLOCK_REGEX.find(input)?.groupValues?.getOrNull(1) ?: input
+
+        if (rawMessage.lines().size > maxLines && guesser.guessLanguage(rawMessage) != null) {
+            val message = event.channel.sendMessage(buildTooLongEmbed()).await()
+            val hasteUrl = beautifier.formatCode(rawMessage).thenCompose {
+                HastebinUtil.postErrorToHastebin(it, bot.httpClient)
+            }.await()
+            message.editMessage(buildTooLongEmbed(hasteUrl)).queue()
+        }
+
+        if (userLevel >= levelLimit) return
         val conversation by lazy { brain.findConversation(event) }
 
         for (future in inputs) {
-            val userInput = future.await()
+            val userInput = (future.await() + rawMessage)
             userInput.forEach {
                 if (it != null) {
                     JVM_EXCEPTION_PATTERN.findAll(it).forEach { match ->
@@ -87,21 +107,33 @@ class AutoHelp(
         }
     }
 
+    private fun buildTooLongEmbed(url: String? = null): EmbedConvention {
+        return Embeds.warn(
+            "Huch, ist das viel?",
+            """Bitte sende lange Codeteile nicht über den Chat oder als Datei, sondern benutze stattdessen ein haste-Tool. Mehr dazu findest du bei `sudo tag haste`.
+                                        |Faustregel: Alles, was mehr als $maxLines Zeilen hat.
+                                        |Hier, ich mache das schnell für dich: ${url ?: Emotes.LOADING}
+                                    """.trimMargin()
+        )
+    }
+
     companion object {
-        // https://regex101.com/r/vgz86r/16
-        val JVM_EXCEPTION_PATTERN =
+        /**
+         * https://regex101.com/r/vgz86r/16
+         */
+        val JVM_EXCEPTION_PATTERN: Regex =
             """(?m)^(?:Exception in thread ".*")?.*?(.+?(?<=Exception|Error:))(?:\: )?(.*)((?:\R+^\s*.*)?(?:\R+^.*at .*)+)""".toRegex()
 
-        // https://regex101.com/r/HtaGF8/1
-        val JVM_EXCEPTION_NAME_PATTERN =
-            """(?m)^(?:Exception in thread ".*")?.*?(.+?(?<=Exception|Error))(?:\: )(.*)(?:\R+^\s*.*)?""".toRegex()
+        /**
+         * https://regex101.com/r/xYGH0m/1
+         */
+        val STACK_TRACE_ELEMENT_PATTERN: Regex = "at ((?:(?:\\w)+\\.?)+)\\.(\\w+)\\((\\w+).java:([0-9]+)\\)".toRegex()
 
-        // https://regex101.com/r/xYGH0m/1
-        val STACK_TRACE_ELEMENT_PATTERN = "at ((?:(?:\\w)+\\.?)+)\\.(\\w+)\\((\\w+).java:([0-9]+)\\)".toRegex()
-
-        // Java class pattern (should match kotlin (maybe))
-        // https://regex101.com/r/uksxY5/3
-        val JAVA_CLASS_PATTERN =
+        /**
+         * Java class pattern (should match kotlin (maybe))
+         * https://regex101.com/r/uksxY5/3
+         */
+        val JAVA_CLASS_PATTERN: Regex =
             """(?m)package ((?:\w+\.?)+);[\s\S]*(public|private|protected) class (\w*) \{([\s\S]*)}""".toRegex()
 
     }

--- a/src/main/kotlin/com/github/devcordde/devcordbot/core/autohelp/Brain.kt
+++ b/src/main/kotlin/com/github/devcordde/devcordbot/core/autohelp/Brain.kt
@@ -1,0 +1,185 @@
+/*
+ * Copyright 2020 Daniel Scherf & Michael Rittmeister & Julian König
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package com.github.devcordde.devcordbot.core.autohelp
+
+import com.github.devcordde.devcordbot.constants.Embeds
+import com.github.devcordde.devcordbot.database.Tag
+import com.github.devcordde.devcordbot.database.Tags
+import com.github.devcordde.devcordbot.dsl.EmbedConvention
+import com.github.devcordde.devcordbot.dsl.editMessage
+import com.github.devcordde.devcordbot.event.DevCordGuildMessageReceivedEvent
+import com.github.devcordde.devcordbot.util.Googler
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.time.delay
+import okhttp3.OkHttpClient
+import org.jetbrains.exposed.sql.transactions.transaction
+import java.time.Duration
+import java.time.OffsetDateTime
+
+/**
+ * I mean not actully a brain but the name sounds cool.
+ */
+class Brain(
+    knownLanguages: List<String>,
+    private val httpClient: OkHttpClient,
+    private val maxLines: Int,
+    googler: Googler
+) {
+
+    private val shortTimeMemory = mutableListOf<Conversation>()
+    private val javadocFinder = JavaDocFinder(googler)
+    private val guesser = LanguageGusser(knownLanguages)
+    private val beautifier = CodeBeautifier(httpClient)
+
+    init {
+        cleanShortTimeMemory()
+    }
+
+    internal fun findConversation(event: DevCordGuildMessageReceivedEvent): Conversation {
+        val found = shortTimeMemory.firstOrNull { it.owner == event.member && it.textChannel == event.channel }
+        if (found == null) {
+
+            val conversation = Conversation(
+                event.member!!,
+                event.message,
+                mutableListOf(),
+                mutableListOf(),
+                null,
+                OffsetDateTime.now()
+            )
+
+            shortTimeMemory.add(conversation)
+
+            return conversation
+        }
+        return found
+    }
+
+    internal fun determinedException(conversation: Conversation, exception: StackTrace) {
+        if (conversation.answer.exception?.sealed == true) return
+        conversation.stacktraces.add(exception)
+        conversation.lastInteraction = OffsetDateTime.now()
+        think(conversation)
+    }
+
+    internal fun determinedClass(conversation: Conversation, clazz: Class) {
+        conversation.classes.add(clazz)
+        conversation.lastInteraction = OffsetDateTime.now()
+        think(conversation)
+    }
+
+    private fun think(conversation: Conversation) {
+        conversation.findException()
+        conversation.findCause()
+        if (conversation.answer.useless) return
+        conversation.safeHelpMessage.editMessage(conversation.answer.toEmbed()).queue()
+        if (conversation.answer.isComplete) {
+            shortTimeMemory.remove(conversation)
+        }
+        tryToFindJavadoc(conversation)
+    }
+
+    private fun tryToFindJavadoc(conversation: Conversation) {
+        GlobalScope.launch {
+            val exception = conversation.answer.exception
+            if (exception != null) {
+                val javadoc = javadocFinder.findJavadocForClass(exception.exceptionName)
+                conversation.answer.exception?.exceptionDoc = javadoc
+                conversation.safeHelpMessage.editMessage(conversation.answer.toEmbed()).queue()
+            }
+        }
+    }
+
+    private fun Conversation.findException() {
+        if (stacktraces.isEmpty()) return
+        for (stacktrace in stacktraces) {
+            val possibleAnswer = handleCommonException(stacktrace) ?: continue
+            val stacktraceElement = stacktrace.elements.first()
+            answer.exception = ConversationAnswer.ExceptionAnswer(
+                stacktrace.exceptionName,
+                possibleAnswer,
+                stacktraceElement.className,
+                stacktraceElement.lineNumber
+            )
+        }
+
+        if (answer.exception == null) {
+            val stacktrace = stacktraces.first()
+            val stacktraceElement = stacktrace.elements.first()
+            answer.exception = ConversationAnswer.ExceptionAnswer(
+                stacktrace.exceptionName,
+                null,
+                stacktraceElement.className,
+                stacktraceElement.lineNumber
+            )
+        }
+    }
+
+    private fun Conversation.findCause() {
+        val exception = answer.exception ?: return
+        for ((_, name, rawContent) in classes) {
+            if (name != exception.causeClass) continue
+            answer.causeContent = rawContent.lines()
+                .getOrNull(exception.causeLine - 1)?.let { "`${it.trim()}`" }
+                ?: "Der Inhalt konnte nicht gefunden werden bitte stelle sicher die ganze Klasse zu senden"
+        }
+    }
+
+
+    private fun buildTooLongEmbed(url: String): EmbedConvention {
+        return Embeds.warn(
+            "Huch, ist das viel?",
+            """Bitte sende lange Codeteile nicht über den Chat oder als Datei, sondern benutze stattdessen ein haste-Tool. Mehr dazu findest du bei `sudo tag haste`.
+                                        |Faustregel: Alles, was mehr als $maxLines Zeilen hat.
+                                        |Hier, ich mache das schnell für dich: $url
+                                    """.trimMargin()
+        )
+    }
+
+    private fun handleCommonException(match: StackTrace) =
+        handleCommonException(match.exceptionName, match.message)
+
+    private fun handleCommonException(
+        exception: String,
+        message: String
+    ): String? {
+        val exceptionName = exception.substring(exception.lastIndexOf('.') + 1).toLowerCase().trim()
+        val tag = when {
+            exceptionName == "nullpointerexception" -> "nullpointerexception"
+            exceptionName == "unsupportedclassversionerror" -> "class-version"
+            exceptionName == "ClassCastException" -> "casting"
+            message == "Plugin already initialized!" -> "plugin-already-initialized"
+            exceptionName == "invaliddescriptionexception" -> "plugin.yml"
+            exceptionName == "invalidpluginexception" && "cannot find main class" in message.toLowerCase() -> "main-class-not-found"
+            else -> null
+        } ?: return null
+        val tagContent = transaction { Tag.find { Tags.name eq tag }.firstOrNull() } ?: return null
+        return tagContent.content
+    }
+
+    private fun cleanShortTimeMemory() {
+        GlobalScope.launch {
+            while (true) {
+                delay(Duration.ofSeconds(30))
+                shortTimeMemory.removeAll {
+                    Duration.between(it.lastInteraction, OffsetDateTime.now()) > Duration.ofSeconds(30)
+                }
+            }
+        }
+    }
+}

--- a/src/main/kotlin/com/github/devcordde/devcordbot/core/autohelp/Brain.kt
+++ b/src/main/kotlin/com/github/devcordde/devcordbot/core/autohelp/Brain.kt
@@ -115,7 +115,7 @@ class Brain(
             postfix = "`)"
         )} scheint null zu sein.
         |Bitte stelle sicher, dass alle davon einen Wert haben oder füge ein `Null-Check` hinzu.
-        |**Tipp**: Füge einen Breakpoint zur zeile `$lineNumber` hinzu um zu checken was genau `null` ist oder benutze die [Helpful NPEs](https://openjdk.java.net/jeps/358) von Java 14+.
+        |**Tipp**: Füge einen Breakpoint zur Zeile `$lineNumber` hinzu um zu checken was genau `null` ist oder benutze die [Helpful NPEs](https://openjdk.java.net/jeps/358) von Java 14+.
     """.trimMargin()
 
     private fun tryToFindJavadoc(conversation: Conversation) {

--- a/src/main/kotlin/com/github/devcordde/devcordbot/core/autohelp/Brain.kt
+++ b/src/main/kotlin/com/github/devcordde/devcordbot/core/autohelp/Brain.kt
@@ -126,7 +126,7 @@ class Brain(
                 exception.explanation = exception.explanation ?: doc.description
                 exception.exceptionDoc = doc.uri
             } else {
-                exception.exceptionDoc = "Ich konnte kein doc finden :C"
+                exception.exceptionDoc = "Es wurde kein Doc gefunden"
             }
             conversation.update()
         }

--- a/src/main/kotlin/com/github/devcordde/devcordbot/core/autohelp/ContentFetcher.kt
+++ b/src/main/kotlin/com/github/devcordde/devcordbot/core/autohelp/ContentFetcher.kt
@@ -16,20 +16,120 @@
 
 package com.github.devcordde.devcordbot.core.autohelp
 
+import com.github.devcordde.devcordbot.util.GithubUtil
 import com.github.devcordde.devcordbot.util.executeAsync
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.future.await
+import kotlinx.coroutines.future.future
+import net.dv8tion.jda.api.entities.Message
 import okhttp3.OkHttpClient
 import okhttp3.Request
+import java.io.BufferedReader
+import java.io.InputStreamReader
 import java.util.concurrent.CompletableFuture
 
 /**
  * ContentFetcher
  */
-class ContentFetcher(private val httpClient: OkHttpClient) {
+class ContentFetcher(
+    private val httpClient: OkHttpClient,
+    private val github: GithubUtil,
+    private val executor: CoroutineDispatcher
+) {
+
+    /**
+     * Trigger AutoHelp on Message.
+     */
+    suspend fun fetchMessageContents(message: Message): List<CompletableFuture<out List<String?>>> {
+        val input = message.contentRaw
+
+        // Asynchronously fetch potential content
+        val attachments = fetchAttachments(message)
+        val messageContents: MutableList<CompletableFuture<List<String?>>> = if (input.isNotBlank()) {
+            val hastebinMatches = findInput(HASTEBIN_PATTERN, input, ::fetchHastebin)
+            val pastebinMatches = findInput(PASTEBIN_PATTERN, input, ::fetchPastebin)
+            val ghostbinMatches = findInput(GHOSTBIN_PATTERN, input, ::fetchGhostbin)
+            val githubMatches = findInputs(GITHUB_GIST_PATTERN, input, ::fetchGithub)
+
+            mutableListOf(hastebinMatches, pastebinMatches, ghostbinMatches, githubMatches)
+        } else mutableListOf()
+        return messageContents.plus(attachments).plus(CompletableFuture.completedFuture(listOf(input))).toList()
+    }
+
+    private fun findInput(
+        pattern: Regex,
+        input: String,
+        fetcher: (MatchResult) -> CompletableFuture<String?>
+    ): CompletableFuture<List<String?>> {
+        return GlobalScope.future(executor) {
+            pattern.findAll(input).toList().map {
+                fetcher(it).await()
+            }
+        }
+    }
+
+    private fun findInputs(
+        pattern: Regex,
+        input: String,
+        fetcher: (MatchResult, String) -> CompletableFuture<List<String?>>
+    ): CompletableFuture<List<String?>> {
+        return GlobalScope.future(executor) {
+            pattern.findAll(input).toList().map {
+                fetcher(it, input).await()
+            }.flatten()
+        }
+    }
+
+    private suspend fun fetchAttachments(message: Message): CompletableFuture<List<String?>> {
+        return GlobalScope.future(executor) {
+            message.attachments.filter { !it.isVideo && !it.isImage }.map {
+                fetchAttachment(it)
+            }
+        }
+    }
+
+    private suspend fun fetchAttachment(attachment: Message.Attachment): String {
+        val stream = attachment.retrieveInputStream().await()
+        return BufferedReader(InputStreamReader(stream)).use { reader ->
+            reader.readText()
+        }
+    }
+
+    private fun fetchHastebin(match: MatchResult): CompletableFuture<String?> {
+        val domain = match.groupValues[1]
+        val pasteId = match.groupValues[2]
+        val rawPaste = "https://$domain/raw/$pasteId"
+        return fetchWebContent(rawPaste)
+    }
+
+    private fun fetchPastebin(match: MatchResult): CompletableFuture<String?> {
+        val pasteId = match.groupValues[1]
+        val rawPaste = "https://pastebin.com/raw/$pasteId"
+        return fetchWebContent(rawPaste)
+    }
+
+    private fun fetchGhostbin(match: MatchResult): CompletableFuture<String?> {
+        val pasteId = match.groupValues[1]
+        val rawPaste = "https://ghostbin.co/paste/$pasteId/raw"
+        return fetchWebContent(rawPaste)
+    }
+
+    private fun fetchGithub(match: MatchResult, url: String): CompletableFuture<List<String?>> {
+        val host = match.groupValues[1]
+        val gistId = match.groupValues[3]
+        if (host == "gist.githubusercontent.com") {
+            return fetchWebContent(url).thenApply { listOf(it) }
+        }
+        return github.retrieveGistFiles(gistId).thenApplyAsync { fileUrls ->
+            fileUrls.map { fetchWebContent(it).join() }
+        }
+    }
 
     /**
      * Fetch content from given Url.
      */
-    fun fetchContent(url: String): CompletableFuture<String?> {
+    private fun fetchWebContent(url: String): CompletableFuture<String?> {
         val request = Request.Builder()
             .url(url)
             .get()
@@ -39,5 +139,25 @@ class ContentFetcher(private val httpClient: OkHttpClient) {
                 it?.string()
             }
         }
+    }
+
+    companion object {
+
+        // https://regex101.com/r/u0QAR6/6
+        private val HASTEBIN_PATTERN =
+            "(?:https?:\\/\\/)?(?:(?:www\\.)?)?(hastebin\\.com|hasteb\\.in|paste\\.helpch\\.at)\\/(?:raw\\/)?(.+?(?=\\.|\$|\\/|#))".toRegex()
+
+        // https://regex101.com/r/N8NBDz/2
+        private val PASTEBIN_PATTERN =
+            "(?:https?:\\/\\/(?:www\\.)?)?pastebin\\.com\\/(?:raw\\/)?(.+?(?=\\.|\$|\\/|#))".toRegex()
+
+        // https://regex101.com/r/CyjiKt/2
+        private val GHOSTBIN_PATTERN =
+            "(?:https?:\\/\\/(?:www\\.)?)?(?:ghostbin\\.co)\\/(?:paste\\/)?(.+?(?=\\.|\$|\\/))(?:\\/raw)?".toRegex()
+
+        // https://regex101.com/r/AlVYjn/2
+        private val GITHUB_GIST_PATTERN =
+            "(?:https?:\\/\\/)?(gist\\.github\\.com|gist.githubusercontent.com)\\/(.+?(?=\\.|\$|\\/))\\/(.+?(?=\\.|\$|\\/|#))".toRegex()
+
     }
 }

--- a/src/main/kotlin/com/github/devcordde/devcordbot/core/autohelp/ContentFetcher.kt
+++ b/src/main/kotlin/com/github/devcordde/devcordbot/core/autohelp/ContentFetcher.kt
@@ -54,7 +54,7 @@ class ContentFetcher(
 
             mutableListOf(hastebinMatches, pastebinMatches, ghostbinMatches, githubMatches)
         } else mutableListOf()
-        return messageContents.plus(attachments).plus(CompletableFuture.completedFuture(listOf(input))).toList()
+        return messageContents.plus(attachments).toList()
     }
 
     private fun findInput(

--- a/src/main/kotlin/com/github/devcordde/devcordbot/core/autohelp/Conversation.kt
+++ b/src/main/kotlin/com/github/devcordde/devcordbot/core/autohelp/Conversation.kt
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2020 Daniel Scherf & Michael Rittmeister & Julian König
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package com.github.devcordde.devcordbot.core.autohelp
+
+import com.github.devcordde.devcordbot.constants.Embeds
+import com.github.devcordde.devcordbot.constants.Emotes
+import com.github.devcordde.devcordbot.dsl.EmbedConvention
+import com.github.devcordde.devcordbot.dsl.sendMessage
+import net.dv8tion.jda.api.entities.Member
+import net.dv8tion.jda.api.entities.Message
+import net.dv8tion.jda.api.entities.TextChannel
+import java.time.OffsetDateTime
+
+/**
+ * Interface for possible autp-help user input
+ */
+interface AutoHelpItem
+
+/**
+ * Representation of a parsed Stack trace element.
+ *
+ * @property pakage the package of the class of the element
+ * @property method the name of the method that was called
+ * @property className the name of the class
+ * @property lineNumber the
+ */
+data class StackTraceElement(val pakage: String, val method: String, val className: String, val lineNumber: Int)
+
+/**
+ * Representation of a Stacktrace.
+ *
+ * @property exceptionName the name of the exception
+ * @property message the message
+ * @property elements a list of [StacktTraceElement]s
+ */
+data class StackTrace(
+    val exceptionName: String,
+    val message: String,
+    val elements: List<StackTraceElement>
+) : AutoHelpItem
+
+/**
+ * Representation of a class.
+ *
+ * @property pakage the package of the class
+ * @property name the name of the class
+ * @property rawContent the raw content of the class
+ */
+data class Class(val pakage: String, val name: String, val rawContent: String) : AutoHelpItem
+
+/**
+ * Representation of a "Conversation" for autohelp.
+ *
+ * @property owner the user starting the conversation
+ * @property trigger the initial message
+ * @property stacktraces a list of [StackTrace]s provided by the user
+ * @property classes a list of [Class]es provided by the user7
+ * @property helpMessage the helpmessage sent by the bot
+ * @property lastInteraction the [OffsetDateTime] of the last interaction in this conversation
+ * @property answer the [ConversationAnswer]
+ */
+data class Conversation(
+    val owner: Member,
+    val trigger: Message,
+    val stacktraces: MutableList<StackTrace>,
+    val classes: MutableList<Class>,
+    var helpMessage: Message?,
+    var lastInteraction: OffsetDateTime,
+    val answer: ConversationAnswer = ConversationAnswer(null, null)
+) {
+    /**
+     * The text Channel the message is in.
+     */
+    val textChannel: TextChannel
+        get() = trigger.textChannel
+
+    /**
+     * Creates message if needed.
+     */
+    val safeHelpMessage: Message
+        get() {
+            if (helpMessage == null) {
+                helpMessage = trigger.channel.sendMessage(
+                    Embeds.loading(
+                        "Ich denke nach!",
+                        "Ich versuche zu helfen bitte warte etwas."
+                    )
+                ).complete()
+            }
+            return helpMessage!!
+        }
+}
+
+/**
+ * Mutable object to store information on how to answer an error.
+ *
+ * @property exception the exception daat
+ * @property causeContent the raw string of the line causing the issue
+ * @property useless whether this answer does contain any useful info or not
+ * @property isComplete whether all information was found or not
+ */
+data class ConversationAnswer(var exception: ExceptionAnswer?, var causeContent: String?) {
+    val useless: Boolean
+        get() = exception == null && causeContent == null
+
+    val isComplete: Boolean
+        get() = exception != null && causeContent != null
+
+    /**
+     * Info about the exception.
+     *
+     * @property exceptionName the name of the exception
+     * @property explanation the tag explaining the exception
+     * @property causeClass the class in which the exception is caused
+     * @property causeLine the line in which the exception is caused
+     * @property exceptionDoc a URL to the exceptions javadoc
+     * @property sealed whether this is the final exception data or not
+     */
+    data class ExceptionAnswer(
+        val exceptionName: String,
+        val explanation: String?,
+        val causeClass: String,
+        val causeLine: Int,
+        var exceptionDoc: String? = null,
+        var sealed: Boolean = false
+    )
+
+    /**
+     * Converts the answer into a user-friendly embed.
+     */
+    fun toEmbed(): EmbedConvention = Embeds.info("AutoHelp - ${exception?.exceptionName}", exception?.explanation) {
+
+        addField("Exception", exception?.exceptionName ?: Emotes.LOADING)
+        addField("Exception Doc", exception?.exceptionDoc ?: Emotes.LOADING)
+        addField(
+            "Ursache",
+            "Der Fehler befindet sich vermutlich in der Datei `${exception?.causeClass}.java` in Zeile `${exception?.causeLine}`"
+        )
+
+        addField(
+            "Ursache - Code",
+            causeContent
+                ?: "Ich konnte keinen Code finden, bitte schicke die komplette Klasse in der der Fehler auftritt (Am besten via hastebin)"
+        )
+
+
+        footer("AutoHelp V1 BETA - Bitte Bugs auf GitHub.com/devcordde/DevcordBot melden.")
+    }
+}

--- a/src/main/kotlin/com/github/devcordde/devcordbot/core/autohelp/ImageReader.kt
+++ b/src/main/kotlin/com/github/devcordde/devcordbot/core/autohelp/ImageReader.kt
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2020 Daniel Scherf & Michael Rittmeister & Julian König
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package com.github.devcordde.devcordbot.core.autohelp
+
+import com.google.cloud.vision.v1.AnnotateImageRequest
+import com.google.cloud.vision.v1.Feature
+import com.google.cloud.vision.v1.Image
+import com.google.cloud.vision.v1.ImageAnnotatorClient
+import com.google.protobuf.ByteString
+import mu.KotlinLogging
+import net.dv8tion.jda.api.utils.data.DataObject
+import java.io.InputStream
+import java.nio.ByteBuffer
+import java.nio.channels.FileChannel
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardOpenOption
+import java.time.Duration
+import java.time.Instant
+
+
+private val LOG = KotlinLogging.logger { }
+
+/**
+ * Utility to read content of images.
+ */
+object ImageReader {
+
+    /**
+     * Whether ratelimit has been hit or not
+     */
+    val available: Boolean
+        get() = Ratelimiter.isAvailable
+    private val client = ImageAnnotatorClient.create()
+
+    /**
+     * Reads the image from [inputStream].
+     */
+    fun readImage(inputStream: InputStream): String? = try {
+        sendRequest(inputStream)
+    } catch (e: Exception) {
+        LOG.error(e) { "Could not read image" }
+        null
+    }
+
+    private fun sendRequest(inputStream: InputStream): String? {
+        if (!Ratelimiter.isAvailable) return null
+        Ratelimiter.register()
+        val imageBytes = ByteString.readFrom(inputStream)
+        val image = Image.newBuilder().setContent(imageBytes).build()
+        val findTextFeature = Feature.newBuilder().setType(Feature.Type.TEXT_DETECTION).build()
+        val request = AnnotateImageRequest.newBuilder().addFeatures(findTextFeature).setImage(image).build()
+        val response = client.batchAnnotateImages(listOf(request)).responsesList.first()
+        if (response.hasError()) {
+            LOG.error { "Could not read image: ${response.error.message}" }
+            return null
+        }
+        return response.textAnnotationsList.firstOrNull()?.description
+    }
+}
+
+private object Ratelimiter {
+
+    private const val MAX_REQUESTS = 1000
+    private val file = Path.of("ocr_usages.json")
+    private var stats: Stats =
+        Stats(Long.MAX_VALUE, Instant.MAX) // initialize with to high value before reading real data
+        set(value) {
+            field = value
+            stats.save()
+        }
+
+    val isAvailable: Boolean
+        get() {
+            return if (Duration.between(Instant.now(), stats.lastUpdate) < Duration.ofDays(31).negated()) {
+                stats = Stats(0, Instant.now())
+                true
+            } else {
+                stats.usages < MAX_REQUESTS
+            }
+        }
+
+    init {
+        stats = if (Files.exists(file)) {
+            val bytes = Files.readAllBytes(file)
+            Stats.fromJson(bytes)
+        } else {
+            Files.createFile(file)
+            val newStats = Stats(0, Instant.now())
+            newStats.save()
+            newStats // return
+        }
+    }
+
+    fun register() {
+        stats = stats.copy(usages = stats.usages + 1)
+        stats.save()
+    }
+
+    private fun Stats.save() {
+        FileChannel.open(file, StandardOpenOption.WRITE).use {
+            it.write(ByteBuffer.wrap(toJson()))
+        }
+    }
+
+    private data class Stats(val usages: Long, val lastUpdate: Instant) {
+        fun toJson(): ByteArray = DataObject.empty()
+            .put("usages", usages)
+            .put("last_update", lastUpdate.toEpochMilli())
+            .toJson()
+
+        companion object {
+            fun fromJson(bytes: ByteArray): Stats {
+                val json = DataObject.fromJson(bytes)
+                return Stats(json.getLong("usages"), Instant.ofEpochMilli(json.getLong("last_update")))
+            }
+        }
+    }
+}

--- a/src/main/kotlin/com/github/devcordde/devcordbot/core/autohelp/JavaDocFinder.kt
+++ b/src/main/kotlin/com/github/devcordde/devcordbot/core/autohelp/JavaDocFinder.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2020 Daniel Scherf & Michael Rittmeister & Julian König
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package com.github.devcordde.devcordbot.core.autohelp
+
+import com.github.devcordde.devcordbot.core.JavaDocManager
+import com.github.devcordde.devcordbot.util.Googler
+
+class JavaDocFinder(private val googler: Googler) {
+
+    fun findJavadocForClass(clazz: String): String {
+        val index = clazz.lastIndexOf('.')
+        val pakage = clazz.take(index)
+        val className = clazz.drop(index + 1)
+        val identifier = if (pakage.startsWith("java")) {
+            "java"
+        } else {
+            pakage.take(pakage.indexOf('.', pakage.indexOf('.') + 1))
+        }
+
+        val javadoc = JavaDocManager.javadocPool[identifier] ?: return googleJavadoc(className)
+        return javadoc.find(pakage, className).firstOrNull()?.uri?.toMarkDownUrl()
+            ?: "Ich konnte kein javadoc finden :("
+    }
+
+    private fun googleJavadoc(clazz: String): String {
+        val query = "$clazz javadoc"
+        return googler.google(query)
+            .firstOrNull { it.htmlTitle.contains("API", ignoreCase = true); true }?.formattedUrl?.toMarkDownUrl()
+            ?: "Ich konnte keine Docs finden"
+    }
+
+    private fun String.toMarkDownUrl() = "[$this]($this)"
+}

--- a/src/main/kotlin/com/github/devcordde/devcordbot/core/autohelp/JavaDocFinder.kt
+++ b/src/main/kotlin/com/github/devcordde/devcordbot/core/autohelp/JavaDocFinder.kt
@@ -21,12 +21,20 @@ import com.github.devcordde.devcordbot.util.Googler
 import com.github.johnnyjayjay.javadox.DocumentedType
 import com.github.johnnyjayjay.javadox.Javadocs
 
+/**
+ * Utility class to find Javadocs
+ *
+ * @param googler [Googler] instance to google javadoc
+ */
 class JavaDocFinder(private val googler: Googler) {
 
+    /**
+     * Tries to find the javadoc for [clazz]
+     */
     fun findJavadocForClass(clazz: String): DocumentedType? {
         val index = clazz.lastIndexOf('.')
-        val pakage = clazz.take(index)
-        val className = clazz.drop(index + 1)
+        val pakage = clazz.take(index).trim()
+        val className = clazz.drop(index + 1).trim()
         val identifier = if (pakage.startsWith("java")) {
             "java"
         } else {
@@ -43,9 +51,9 @@ class JavaDocFinder(private val googler: Googler) {
         val rawUrl = googler.google(query)
             .firstOrNull { it.htmlTitle.contains("API", ignoreCase = true); true }?.formattedUrl
         return rawUrl?.let {
-            val pakage = clazz.take(clazz.indexOf('.'))
+            val pakage = clazz.take(clazz.indexOf('.')).replace('.', '/')
             val url = rawUrl.take(rawUrl.indexOf(pakage))
-            JavaDocManager.makeJavadoc(url)
+            JavaDocManager.makeJavadoc(pakage, url)
         }
     }
 }

--- a/src/main/kotlin/com/github/devcordde/devcordbot/core/autohelp/StackTraceAnalyzer.kt
+++ b/src/main/kotlin/com/github/devcordde/devcordbot/core/autohelp/StackTraceAnalyzer.kt
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2020 Daniel Scherf & Michael Rittmeister & Julian König
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package com.github.devcordde.devcordbot.core.autohelp
+

--- a/src/main/kotlin/com/github/devcordde/devcordbot/util/Googler.kt
+++ b/src/main/kotlin/com/github/devcordde/devcordbot/util/Googler.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020 Daniel Scherf & Michael Rittmeister & Julian König
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package com.github.devcordde.devcordbot.util
+
+import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport
+import com.google.api.client.json.jackson2.JacksonFactory
+import com.google.api.services.customsearch.Customsearch
+import com.google.api.services.customsearch.model.Result
+
+/**
+ * Utility to google things.
+ */
+class Googler(private val apiKey: String, private val engineId: String) {
+
+    private val search =
+        Customsearch.Builder(GoogleNetHttpTransport.newTrustedTransport(), JacksonFactory(), null)
+            .setApplicationName("DevcordBot")
+            .build()
+
+    /**
+     * Googles the [query].
+     */
+    fun google(query: String): List<Result> {
+        return with(search.cse().list(query)) {
+            key = apiKey
+            cx = engineId
+            execute()
+        }.items ?: emptyList()
+    }
+}


### PR DESCRIPTION
## Bugfixes
This PR changes handling of javadocs
from now on the bot will disable the Javadoc command when it errors while fetching the doc.
I also changed java 9-14 doc to an openjdk hosted version because oracles version is trash

## Autohelp changes
the bot does now also analyze code and highlighted the line that caused the exception according to the stacktrace
if there is no tag for an exception the bot will try to fetch the Javadoc for it

## Todo
.~~- [ ] Handy non-domainish groups ids properly (e.g. okhttp3)~~
- [x] try to find first user element in stack trace


## Github
Fix #103 
Fix #102 
Fix #101
Fix #100 
Fix #99 
Fix #98