### PR TITLE
Fix bugs in AutoHelp.kt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,3 +129,4 @@ gradle-app.setting
 
 # GCP Vision
 ServiceAccountKey.json
+/ocr_usages.json

--- a/.gitignore
+++ b/.gitignore
@@ -129,4 +129,4 @@ gradle-app.setting
 
 # GCP Vision
 ServiceAccountKey.json
-/ocr_usages.json
+ocr_usages.json

--- a/src/main/kotlin/com/github/devcordde/devcordbot/core/autohelp/AutoHelp.kt
+++ b/src/main/kotlin/com/github/devcordde/devcordbot/core/autohelp/AutoHelp.kt
@@ -32,6 +32,7 @@ import io.github.cdimascio.dotenv.dotenv
 import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.future.await
 import org.jetbrains.exposed.sql.transactions.transaction
+import java.util.concurrent.CompletableFuture
 import java.util.concurrent.Executors
 
 private val levelLimit = dotenv()["AUTO_HELP_LEVEL_LIMIT"]?.toInt() ?: 75
@@ -105,26 +106,32 @@ class AutoHelp(
         }
 
         if (userLevel >= levelLimit) return
-        val conversation by lazy { brain.findConversation(event) }
+        val newConversation = { brain.findConversation(event) }
+        val container = ConversationContainer(newConversation)
 
-        for (future in inputs) {
-            val userInput = (future.await() + messageContents.map { it.second })
-            userInput.forEach {
+        for (future in (inputs + CompletableFuture.completedFuture(messageContents.map { it.second }))) {
+            val userInput = future.await()
+            userInput.toList().forEach {
                 if (it != null) {
-                    JVM_EXCEPTION_PATTERN.findAll(it).forEach { match ->
+                    JVM_EXCEPTION_PATTERN.findAll(it).toList().forEach { match ->
                         val root = match.groupValues.drop(1)
                         val rootException = parseException(root)
-                        val finalException = if (root.size > 3) {
-                            val cause = root.drop(5)
+                        val cause = root.drop(5).filterNot(String::isNullOrBlank)
+                        val finalException = if (cause.isNotEmpty()) {
                             val causeException = parseException(cause)
                             rootException.copy(cause = causeException)
                         } else rootException
-                        brain.determinedException(conversation, finalException)
+
+                        if (container.conversation.answer.exceptionSet) {
+                            brain.abandon(container.conversation)
+//                            container.conversation = brain.findConversation(event)
+                        }
+                        brain.determinedException(container.conversation, finalException)
                     }
 
                     JAVA_CLASS_PATTERN.findAll(it).forEach { match ->
                         val (_, pakage, _, name) = match.groupValues
-                        brain.determinedClass(conversation, Class(pakage, name, it))
+                        brain.determinedClass(container.conversation, Class(pakage, name, it))
                     }
                 }
             }
@@ -173,4 +180,15 @@ class AutoHelp(
             """(?m)package ((?:\w+\.?)+);[\s\S]*(public|private|protected) class (\w*) \{([\s\S]*)}""".toRegex()
 
     }
+}
+
+private data class ConversationContainer(
+    private val newConversation: () -> Conversation,
+    private var setConversation: Conversation? = null
+) {
+    var conversation: Conversation
+        get() = setConversation ?: newConversation().also { setConversation = it }
+        set(value) {
+            setConversation = value
+        }
 }

--- a/src/main/kotlin/com/github/devcordde/devcordbot/core/autohelp/AutoHelp.kt
+++ b/src/main/kotlin/com/github/devcordde/devcordbot/core/autohelp/AutoHelp.kt
@@ -111,9 +111,9 @@ class AutoHelp(
 
         for (future in (inputs + CompletableFuture.completedFuture(messageContents.map { it.second }))) {
             val userInput = future.await()
-            userInput.toList().forEach {
+            userInput.forEach {
                 if (it != null) {
-                    JVM_EXCEPTION_PATTERN.findAll(it).toList().forEach { match ->
+                    JVM_EXCEPTION_PATTERN.findAll(it).forEach { match ->
                         val root = match.groupValues.drop(1)
                         val rootException = parseException(root)
                         val cause = root.drop(5).filterNot(String::isNullOrBlank)

--- a/src/main/kotlin/com/github/devcordde/devcordbot/core/autohelp/Conversation.kt
+++ b/src/main/kotlin/com/github/devcordde/devcordbot/core/autohelp/Conversation.kt
@@ -112,7 +112,7 @@ data class Conversation(
      * Updates the Discord answer message.
      */
     fun update(): Unit =
-        safeHelpMessage.editMessage(answer.toEmbed()).queue().also { println(Integer.toHexString(hashCode())) }
+        safeHelpMessage.editMessage(answer.toEmbed()).queue()
 }
 
 /**

--- a/src/main/kotlin/com/github/devcordde/devcordbot/core/autohelp/Conversation.kt
+++ b/src/main/kotlin/com/github/devcordde/devcordbot/core/autohelp/Conversation.kt
@@ -21,6 +21,7 @@ import com.github.devcordde.devcordbot.constants.Emotes
 import com.github.devcordde.devcordbot.dsl.EmbedConvention
 import com.github.devcordde.devcordbot.dsl.editMessage
 import com.github.devcordde.devcordbot.dsl.sendMessage
+import com.github.devcordde.devcordbot.util.limit
 import net.dv8tion.jda.api.entities.Member
 import net.dv8tion.jda.api.entities.Message
 import net.dv8tion.jda.api.entities.TextChannel
@@ -111,7 +112,7 @@ data class Conversation(
      * Updates the Discord answer message.
      */
     fun update(): Unit =
-        safeHelpMessage.editMessage(answer.toEmbed()).queue()
+        safeHelpMessage.editMessage(answer.toEmbed()).queue().also { println(Integer.toHexString(hashCode())) }
 }
 
 /**
@@ -180,7 +181,7 @@ class ConversationAnswer {
             if (exception.causeClass != null) {
                 addField(
                     "Ursache",
-                    "Der Fehler befindet sich vermutlich in der Datei `${exception.causeClass}.java` in Zeile `${exception.causeLine}`"
+                    "Der Fehler befindet sich vermutlich in der Datei `${exception.causeClass?.limit(100)}.java` in Zeile `${exception.causeLine}`"
                 )
             }
 


### PR DESCRIPTION
- Correctly search for blank strings in groupValues to identify exception cause
- Automatically abandon ongoing conversation when a new exception is presented
- Limit length of cause class to 100 chars because @foryasee cannot name his classes properly (Proof: https://rice.by.devs-from.asia/Discord_jZfggDwYPU.png)
- Fix bug causing analysis of text messagee content 5 times