### PR TITLE
Fix Case-sensitive tag names

### DIFF
--- a/src/main/kotlin/com/github/devcordde/devcordbot/commands/general/TagCommand.kt
+++ b/src/main/kotlin/com/github/devcordde/devcordbot/commands/general/TagCommand.kt
@@ -421,6 +421,9 @@ class TagCommand : AbstractCommand() {
         return if (foundTag != null) foundTag else {
             val similarTag =
                 Tag.find { Tags.name similar name }.orderBy(similarity(Tags.name, name) to SortOrder.DESC).firstOrNull()
+            if(name.equals(similarTag.name, true) {
+                return similarTag;
+            }
             val similarTagHint = if (similarTag != null) " Meintest du vielleicht `${similarTag.name}`?" else ""
             return context.respond(
                 Embeds.error(

--- a/src/main/kotlin/com/github/devcordde/devcordbot/commands/general/TagCommand.kt
+++ b/src/main/kotlin/com/github/devcordde/devcordbot/commands/general/TagCommand.kt
@@ -421,8 +421,8 @@ class TagCommand : AbstractCommand() {
         return if (foundTag != null) foundTag else {
             val similarTag =
                 Tag.find { Tags.name similar name }.orderBy(similarity(Tags.name, name) to SortOrder.DESC).firstOrNull()
-            if(name.equals(similarTag.name, true) {
-                return similarTag;
+            if(similarTag != null && name.equals(similarTag.name, true) {
+                return similarTag
             }
             val similarTagHint = if (similarTag != null) " Meintest du vielleicht `${similarTag.name}`?" else ""
             return context.respond(


### PR DESCRIPTION
This pr fixes case-sensitive tag names when a tag is requested (loaded). Because logic in TagCommand.kt isn't really separated at all and I didn't want to significantly change the class outline, I didn't bother adding the case-sensivity check to any other subcommands.

Fixes #105 