### PR TITLE
Removed unnecessary pipeline step

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -26,8 +26,6 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 1.14
-    - name: Grant execute permission for gradlew
-      run: chmod +x gradlew
     - name: Test with Gradle
       run: ./gradlew test 
     - name: Build with Gradle


### PR DESCRIPTION
This removes the unnecessary step to grant execute permissions on the `gradlew` file. \
The step is unnecessary as the file has the execute permission already set.