### PR TITLE
Fix GitHub Profile url

### DIFF
--- a/src/main/kotlin/com/github/devcordde/devcordbot/listeners/SelfMentionListener.kt
+++ b/src/main/kotlin/com/github/devcordde/devcordbot/listeners/SelfMentionListener.kt
@@ -59,7 +59,7 @@ class SelfMentionListener(private val bot: DevCordBot) {
         suspend fun fetchContributors(devCordBot: DevCordBot): String {
             val contributors = devCordBot.github.retrieveContributors()
             return contributors.joinToString(", ") {
-                "[${it.name}](${it.url})"
+                "[${it.name}](${it.htmlUrl})"
             }
         }
 

--- a/src/main/kotlin/com/github/devcordde/devcordbot/util/GithubUtil.kt
+++ b/src/main/kotlin/com/github/devcordde/devcordbot/util/GithubUtil.kt
@@ -47,7 +47,7 @@ class GithubUtil(private val client: HttpClient) {
  * Representation of a Bot contributor on github.
  *
  * @property name the GitHub username of the contributer
- * @property url the url to the contributors GitHub profile
+ * @property htmlUrl the url to the contributors GitHub profile
  */
 @Serializable
-data class GitHubContributor(@SerialName("login") val name: String, val url: String)
+data class GitHubContributor(@SerialName("login") val name: String, @SerialName("html_url") val htmlUrl: String)


### PR DESCRIPTION
The profile links in the info command point to the github api url. With this PR, they point to their profile page.