### PR TITLE
Replace "gebe" with "gib"

### DIFF
--- a/src/main/kotlin/com/github/devcordde/devcordbot/commands/general/TagCommand.kt
+++ b/src/main/kotlin/com/github/devcordde/devcordbot/commands/general/TagCommand.kt
@@ -106,8 +106,8 @@ class TagCommand : AbstractRootCommand() {
             if (newSuspendedTransaction { checkTagExists(name, context) }) return
             val status = context.respond(
                 Embeds.info(
-                    "Bitte gebe den Inhalt an!",
-                    "Bitte gebe den Inhalt des Tags in einer neuen Nachricht an."
+                    "Bitte gib den Inhalt an!",
+                    "Bitte gib den Inhalt des Tags in einer neuen Nachricht an."
                 )
             )
 
@@ -181,8 +181,8 @@ class TagCommand : AbstractRootCommand() {
 
             val status = context.respond(
                 Embeds.info(
-                    "Bitte gebe den Inhalt an!",
-                    "Bitte gebe den Inhalt des Tags in einer neuen Nachricht an."
+                    "Bitte gib den Inhalt an!",
+                    "Bitte gib den Inhalt des Tags in einer neuen Nachricht an."
                 )
             )
 


### PR DESCRIPTION
Please change "Bitte gebe den Inhalt an" with "Bitte gib den Inhalt an". 

This pull request ist just for simplicity, so that this enhancement is not being missed.

Reference: https://www.helpster.de/gib-oder-gebe_196958