### PR TITLE
Fix docker publish workflow step

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -32,7 +32,7 @@ jobs:
           arguments: installDist
       - name: Docker Publish
         if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop'
-        uses: manusa/actions-publish-docker@v1.0.1
+        uses: manusa/actions-publish-docker@v1.1.2
         with:
           name: devcord/devcordbot
           tag: ${{ env.TAG }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM adoptopenjdk/openjdk16-openj9
+FROM eclipse-temurin/17-jdk-alpine
 
 WORKDIR /usr/app
 COPY build/libs/install ./


### PR DESCRIPTION
If updating doesn't work we should switch to another plugin, it appears that the one we currently use is small and no longer maintained. 